### PR TITLE
fix:revise etag

### DIFF
--- a/objectservice/s3api/object_handlers.go
+++ b/objectservice/s3api/object_handlers.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 )
 
-//PutObjectHandler Put ObjectHandler
-//https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
+// PutObjectHandler Put ObjectHandler
+// https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
 func (s3a *s3ApiServer) PutObjectHandler(w http.ResponseWriter, r *http.Request) {
 
 	// http://docs.aws.amazon.com/AmazonS3/latest/dev/UploadingObjects.html
@@ -155,7 +155,7 @@ func (s3a *s3ApiServer) PutObjectHandler(w http.ResponseWriter, r *http.Request)
 // ----------
 // This implementation of the GET operation retrieves object. To use GET,
 // you must have READ access to the object.
-//https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html
+// https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html
 func (s3a *s3ApiServer) GetObjectHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	bucket, object, err := getBucketAndObject(r)
@@ -201,7 +201,7 @@ func (s3a *s3ApiServer) GetObjectHandler(w http.ResponseWriter, r *http.Request)
 }
 
 // HeadObjectHandler - HEAD Object
-//https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html
+// https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html
 // The HEAD operation retrieves metadata from an object without returning the object itself.
 func (s3a *s3ApiServer) HeadObjectHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -245,7 +245,7 @@ func (s3a *s3ApiServer) HeadObjectHandler(w http.ResponseWriter, r *http.Request
 
 // DeleteObjectHandler - delete an object
 // Delete objectAPIHandlers
-//https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html
+// https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html
 func (s3a *s3ApiServer) DeleteObjectHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	bucket, object, err := getBucketAndObject(r)
@@ -519,7 +519,13 @@ func (s3a *s3ApiServer) CopyObjectHandler(w http.ResponseWriter, r *http.Request
 			metadata[key] = val
 		}
 	}
-	obj, err := s3a.store.StoreObject(ctx, dstBucket, dstObject, srcReader, srcObjInfo.Size, metadata)
+	hashReader, err := hash.NewReader(srcReader, srcObjInfo.Size, srcObjInfo.ETag, "", srcObjInfo.Size)
+	if err != nil {
+		log.Errorf("PutObjectHandler NewReader err:%v", err)
+		response.WriteErrorResponse(w, r, apierrors.ToApiError(ctx, err))
+		return
+	}
+	obj, err := s3a.store.StoreObject(ctx, dstBucket, dstObject, hashReader, srcObjInfo.Size, metadata)
 	if err != nil {
 		response.WriteErrorResponse(w, r, apierrors.ToApiError(ctx, err))
 		return
@@ -761,9 +767,9 @@ func trimLeadingSlash(ep string) string {
 
 // Validate all the ListObjects query arguments, returns an APIErrorCode
 // if one of the args do not meet the required conditions.
-// - delimiter if set should be equal to '/', otherwise the request is rejected.
-// - marker if set should have a common prefix with 'prefix' param, otherwise
-//   the request is rejected.
+//   - delimiter if set should be equal to '/', otherwise the request is rejected.
+//   - marker if set should have a common prefix with 'prefix' param, otherwise
+//     the request is rejected.
 func validateListObjectsArgs(marker, delimiter, encodingType string, maxKeys int) apierrors.ErrorCode {
 	// Max keys cannot be negative.
 	if maxKeys < 0 {

--- a/objectservice/store/object_info.go
+++ b/objectservice/store/object_info.go
@@ -6,23 +6,25 @@ import (
 )
 
 // ObjectInfo - represents object metadata.
-//{
-// 	Bucket = {string} "test"
-// 	Name = {string} "default.exe"
-// 	ModTime = {time.Time} 2022-03-18 10:54:43.308685163 +0800
-// 	Size = {int64} 11604147
-// 	IsDir = {bool} false
-// 	ETag = {string} "a6b0b7ddb4630832ed47821af59aa125"
-// 	VersionID = {string} ""
-// 	IsLatest = {bool} false
-// 	DeleteMarker = {bool} false
-// 	ContentType = {string} "application/x-msdownload"
-// 	ContentEncoding = {string} ""
-// 	Expires = {time.Time} 0001-01-01 00:00:00 +0000
-// 	Parts = {[]ObjectPartInfo} nil
-// 	AccTime = {time.Time} 0001-01-01 00:00:00 +0000
-// 	SuccessorModTime = {time.Time} 0001-01-01 00:00:00 +0000
-//}
+//
+//	{
+//		Bucket = {string} "test"
+//		Name = {string} "default.exe"
+//		ModTime = {time.Time} 2022-03-18 10:54:43.308685163 +0800
+//		Size = {int64} 11604147
+//		IsDir = {bool} false
+//		ETag = {string} "a6b0b7ddb4630832ed47821af59aa125"
+//		Cid = {string} "QmRP168AQEN9vz8vnjWdEWiiJbNt4BZ5cB81qSRL5FQfGt"
+//		VersionID = {string} ""
+//		IsLatest = {bool} false
+//		DeleteMarker = {bool} false
+//		ContentType = {string} "application/x-msdownload"
+//		ContentEncoding = {string} ""
+//		Expires = {time.Time} 0001-01-01 00:00:00 +0000
+//		Parts = {[]ObjectPartInfo} nil
+//		AccTime = {time.Time} 0001-01-01 00:00:00 +0000
+//		SuccessorModTime = {time.Time} 0001-01-01 00:00:00 +0000
+//	}
 type ObjectInfo struct {
 	// Name of the bucket.
 	Bucket string
@@ -42,6 +44,8 @@ type ObjectInfo struct {
 	// Hex encoded unique entity tag of the object.
 	ETag string
 
+	// ipfs key
+	Cid string
 	// Version ID of this object.
 	VersionID string
 
@@ -75,6 +79,7 @@ type ObjectInfo struct {
 // file after CompleteMultipartUpload() is called.
 type objectPartInfo struct {
 	ETag    string    `json:"etag,omitempty"`
+	Cid     string    `json:"cid,omitempty"`
 	Number  int       `json:"number"`
 	Size    int64     `json:"size"`
 	ModTime time.Time `json:"mod_time"`


### PR DESCRIPTION
s3 etage correction.
Etag should not be an ipfs cid.
When etag is ipfs cid, s3cmd reports an exception because s3cmd calculates etag and returns comparison
s3cmd put/get test passed.